### PR TITLE
Change inhibition over to events/booleans instead, add MonadMouse/Keyboard instances for some transformers.

### DIFF
--- a/netwire-input.cabal
+++ b/netwire-input.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                netwire-input
-version:             0.0.3
+version:             0.0.4
 synopsis:            Input handling abstractions for netwire
 description:         This package contains a collection of Monad typeclasses that support
                      interaction with input devices such as keyboard and mice. Moreover, these
@@ -13,9 +13,9 @@ description:         This package contains a collection of Monad typeclasses tha
 homepage:            https://www.github.com/Mokosha/netwire-input
 license:             MIT
 license-file:        LICENSE
-author:              Pavel Krajcevski
-maintainer:          Krajcevski@gmail.com
-copyright:           Pavel Krajcevski, 2014
+author:              Pavel Krajcevski, Bradley Hardy
+maintainer:          bradleyhardy@live.com
+copyright:           Pavel Krajcevski, 2014; Bradley Hardy, 2015
 category:            Game
 build-type:          Simple
 extra-source-files:  README.md
@@ -29,7 +29,7 @@ library
   default-extensions:  FunctionalDependencies
                        MultiParamTypeClasses
   exposed-modules:     FRP.Netwire.Input
-  build-depends:       base >=4.6 && <4.8,
-                       netwire >= 5
+  build-depends:       base >=4.6 && <4.9,
+                       netwire >= 5, mtl, transformers
   hs-source-dirs:      lib
   default-language:    Haskell2010


### PR DESCRIPTION
This change might be more controversial than my pull request for netwire-input-glfw. My reasoning was that using them with all the inhibition just didn't feel very idiomatic for Netwire 5.

Either way, all the instances for MonadMouse/Keyboard should be useful on their own, so that GLFWInputT (or the equivalent SDL one, which I haven't updated myself) doesn't have to be at the top of the transformer stack. Maybe you'd just want to merge those instances in on their own.
